### PR TITLE
Make TypeScript type definition better

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -90,7 +90,5 @@ export type Twemoji = {
   onerror(): void;
 };
 
-declare module 'twemoji' {
-  const twemoji: Twemoji;
-  export default twemoji;
-}
+declare const twemoji: Twemoji;
+export default twemoji;

--- a/index.d.ts
+++ b/index.d.ts
@@ -84,7 +84,7 @@ export type Twemoji = {
      */
     toCodePoint(utf16surrogatePairs: string, sep?: string): string;
   };
-  parse<T extends string | HTMLElement>(node: T, options?: TwemojiOptions | ParseCallback): T;
+  parse<T extends string | HTMLElement>(node: T, options?: TwemojiOptions | ParseCallback): T extends string ? string : T;
   replace(text: string, replacer: string | ReplacerFunction): string;
   test(text: string): boolean;
   onerror(): void;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "main": "./dist/twemoji.npm.js",
   "module": "./dist/twemoji.esm.js",
   "unpkg": "./dist/twemoji.min.js",
+  "types": "./index.d.ts",
   "scripts": {
     "build": "./scripts/build.js",
     "deploy": "./scripts/deploy.sh gh-pages",


### PR DESCRIPTION
First, huge thanks to work of you and contributors all about Twemoji!! I have developed [Markdown presentation tools](https://marp.app) that have integrated Twemoji since 7 years ago, and our community also loves Twemoji. I believe `@twemoji/api` becomes a bright step for the future of Twemoji.

This change fixes about type definitions. Use a regular `export` syntax instead of ambient modules, and provide type definitions as Twemoji built-in.

![twemoji-dts](https://user-images.githubusercontent.com/3993388/212471070-4961f9ae-7928-40ec-a956-09a394bbf331.png)

> 9127afd is actually not necessary change to get working Twemoji on TypeScript, but helpful to tell that Twemoji has built-in type definitions. [npm displays blue TS symbol, to show this module is compliant with TypeScript.](https://github.blog/changelog/2020-12-16-npm-displays-packages-with-bundled-typescript-declarations/)