### PR TITLE
Skip CI on CI SVG optimization commit

### DIFF
--- a/.github/workflows/optimize-svgs.yml
+++ b/.github/workflows/optimize-svgs.yml
@@ -28,7 +28,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         if: ${{steps.svgo.outputs.DID_OPTIMIZE}}
         with:
-          commit_message: Optimize ${{steps.svgo.outputs.OPTIMIZED_COUNT}} SVG(s)
+          commit_message: Optimize ${{steps.svgo.outputs.OPTIMIZED_COUNT}} SVG(s) [no ci]
       - name: Comment on Pull Request
         uses: thollander/actions-comment-pull-request@v1
         if: ${{steps.svgo.outputs.DID_OPTIMIZE && github.event_name == 'pull_request'}}


### PR DESCRIPTION
**Problem:** When CI commits SVG optimizations, the GitHub Action for SVG optimizations re-triggers and is never marked as completed.

**Solution:** CI commits shouldn't re-trigger CI. Mark commit to skip CI.