### PR TITLE
Update some legacy references to Twitter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,5 +97,5 @@ commits.
 By contributing your code:
 
 You agree to license your contribution under the terms of the MIT (for code) and CC-BY (for graphics) licenses
-<https://github.com/twitter/twemoji/blob/gh-pages/LICENSE>
-<https://github.com/twitter/twemoji/blob/gh-pages/LICENSE-GRAPHICS>
+<https://github.com/jdecked/twemoji/blob/gh-pages/LICENSE>
+<https://github.com/jdecked/twemoji/blob/gh-pages/LICENSE-GRAPHICS>

--- a/LEGACY.md
+++ b/LEGACY.md
@@ -22,7 +22,7 @@ Following are all the methods exposed in the `twemoji` namespace.
 
 This is the main parsing utility and has 3 overloads per parsing type.
 
-There are mainly two kinds of parsing: [string parsing](https://github.com/twitter/twemoji#string-parsing) and [DOM parsing](https://github.com/twitter/twemoji#dom-parsing).
+There are mainly two kinds of parsing: [string parsing](#string-parsing) and [DOM parsing](#dom-parsing).
 
 Each of them accepts a callback to generate an image source or an options object with parsing info.
 

--- a/component.json
+++ b/component.json
@@ -17,7 +17,7 @@
     "name": "Twitter, Inc.",
     "web": "https://github.com/twitter/"
   },
-  "repository": "twitter/twemoji",
+  "repository": "jdecked/twemoji",
   "main": "twemoji.js",
   "scripts": [
     "twemoji.js"


### PR DESCRIPTION
Fixed a few that I mentioned in #19, which I've checked off there, but:
- unsure of what to touch in regards to licences and author fields
- don't know what to point the build status badge at, considering travis-ci is broken
- no idea what I should do in regard to the jsdelivr npm package links
- can't PR changes to repo description

Feel free to submit your own edits to my branch, considering you're way more experienced here.

Thanks,
Elliott