### PR TITLE
Update SVGO PR action to v4

### DIFF
--- a/.github/workflows/optimize-svgs.yml
+++ b/.github/workflows/optimize-svgs.yml
@@ -18,8 +18,8 @@ jobs:
   run-svgo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: ericcornelissen/svgo-action@v3
+      - uses: actions/checkout@v4
+      - uses: ericcornelissen/svgo-action@v4
         id: svgo
         with:
           repo-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
**Problem:** Warning on SVGO action:
> General support for SVGO Action v3 ended 2023-09-23. Security updates will be supported until 2023-12-31. Please upgrade to SVGO Action v4 as soon as possible.

**Solution:** Bump `ericcornelissen/svgo-action` version