### PR TITLE
Small update to make it more clear what this fork is

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Twitter Emoji (Twemoji)
+# Twemoji
 
 A simple library that provides standard Unicode [emoji](http://en.wikipedia.org/wiki/Emoji) support across all platforms.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A simple library that provides standard Unicode [emoji](http://en.wikipedia.org/
 
 The Twemoji library offers support for all Unicode-defined emoji which are recommended for general interchange (RGI).
 
+This is a fork of [the unmaintained Twitter Emoji set](https://github.com/twitter/twemoji) by the original authors and the community.
+
 ## Usage
 
 ### Install via NPM

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
     <p><strong>Version 15.1.0 is out!</strong></p>
     <p><a href="v/latest/preview-svg.html">Preview all SVG emoji</a></p>
     <p><a href="https://github.com/jdecked/twemoji">Grab me on GitHub &#x2197;</a></p>
+    <p>This is a fork of <a href="https://github.com/twitter/twemoji">the unmaintained Twitter Emoji set</a> by the original authors and the community.</p>
     <p>Code licensed under MIT. Graphics licensed under CC-BY</p>
     <script src="https://cdn.jsdelivr.net/npm/@twemoji/api@latest/dist/twemoji.min.js"></script>
     <script>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Twitter Emoji (Twemoji)</title>
+    <title>Twemoji</title>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -33,16 +33,9 @@
   </head>
   <body>
     <h1>Twem&#x2764;ji</h1>
-    <p>Sharing Twitter emoji <a href="v/latest/preview-svg.html">everywhere</a></p>
-    <p><strong>Version 15.0 Is Out!</strong></p>
-	<p><a href="https://github.com/jdecked/twemoji">Grab me on GitHub &#x2197;</a></p>
-    <p>
-      <a href="https://twitter.com/intent/tweet?button_hashtag=TwemojiParty&text=thank%20you%20Twitter%20for%20the%20emoji" class="twitter-hashtag-button" data-size="large" data-related="twitteross" data-url="http://twitter.github.io/twemoji/">Tweet #TwemojiParty</a>
-      <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-    </p>
-    <blockquote class="twitter-tweet" lang="en" align="center"><p>today we are open sourcing our emoji to share with everyone <a href="https://twitter.com/hashtag/twemojiparty?src=hash">#twemojiparty</a>          ✨ <a href="https://t.co/zkXqMXEkOT">https://t.co/zkXqMXEkOT</a></p>&mdash; Twitter Open Source (@TwitterOSS) <a href="https://twitter.com/TwitterOSS/status/530496382885720064">November 6, 2014</a></blockquote>
-    <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
-
+    <p><strong>Version 15.1.0 is out!</strong></p>
+    <p><a href="v/latest/preview-svg.html">Preview all SVG emoji</a></p>
+    <p><a href="https://github.com/jdecked/twemoji">Grab me on GitHub &#x2197;</a></p>
     <p>Code licensed under MIT. Graphics licensed under CC-BY</p>
     <script src="https://cdn.jsdelivr.net/npm/@twemoji/api@latest/dist/twemoji.min.js"></script>
     <script>

--- a/src/templates/preview.html
+++ b/src/templates/preview.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Twitter Emoji (Twemoji) Preview</title>
+    <title>Twemoji Preview</title>
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <style>
     ul.emoji-list * {


### PR DESCRIPTION
- Replacing “Twitter Emoji“ by “Twemoji” in public facing places (readme, webpage)
- Adding a sentence about the fact that this is a maintained fork in the same places (can be reformulated)
- Removing Twitter-specific things from the webpage (so that at least it makes some sense before a possible new page on #85)