### PR TITLE
Allow user customization of regex used for matching emojis

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,10 @@ export type TwemojiOptions = {
    */
   folder?: string;
   /**
+   * Default: the built-in emoji matching regex
+   */
+  regex?: RegExp;
+  /**
    * The function to invoke in order to generate image src(s).
    */
   callback?: ParseCallback
@@ -43,7 +47,7 @@ export type TwemojiOptions = {
    * @param variant variant the optional \uFE0F ("as image") variant, in case this info is anyhow meaningful. By default this is ignored.
    * 
    */
-  attributes?(icon: string, variant: string): object;
+  attributes?(icon: string, variant: string): Record<string, string>;
 }
 
 export type Twemoji = {
@@ -51,6 +55,8 @@ export type Twemoji = {
   ext: string;
   className: string;
   size: string;
+  regex: RegExp;
+  readonly defaultRegex: RegExp;
   convert: {
     /**
      * Given an HEX codepoint, returns UTF16 surrogate pairs.
@@ -85,7 +91,7 @@ export type Twemoji = {
     toCodePoint(utf16surrogatePairs: string, sep?: string): string;
   };
   parse<T extends string | HTMLElement>(node: T, options?: TwemojiOptions | ParseCallback): T extends string ? string : T;
-  replace(text: string, replacer: string | ReplacerFunction): string;
+  replace(text: string, replacer: string | ReplacerFunction, regex?: RegExp): string;
   test(text: string): boolean;
   onerror(): void;
 };

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -282,8 +282,11 @@ function createTwemoji() {
             return re;
           },
           set: function(value) {
-            // clone upon setting to avoid issues with stateful `lastIndex`
-            re = new RegExp(value);
+            re = value.flags === defaultRegex.flags && value.source === defaultRegex.source
+              // use reference-equal default to re-enable fast path in `replace`
+              ? defaultRegex
+              // else, clone upon setting to avoid issues with stateful `lastIndex`
+              : new RegExp(value);
           },
           enumerable: true
         }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -38,6 +38,13 @@ function createTwemoji() {
       /*jshint maxparams:4 */
 
       var
+        // RegExp based on emoji's official Unicode standards
+        // http://www.unicode.org/Public/UNIDATA/EmojiSources.txt
+        re = /twemoji/,
+        // Keep a reference to the original in case it's changed
+        defaultRegex = re,
+        // Used for skipping any HTML special chars matched by user-supplied regex
+        htmlGroupedRe = /([<>&'"]+)/,
         // the exported module object
         twemoji = {
 
@@ -246,10 +253,6 @@ function createTwemoji() {
           '"': '&quot;'
         },
 
-        // RegExp based on emoji's official Unicode standards
-        // http://www.unicode.org/Public/UNIDATA/EmojiSources.txt
-        re = /twemoji/,
-
         // avoid runtime RegExp creation for not so smart,
         // not JIT based, and old browsers / engines
         UFE0Fg = /\uFE0F/g,
@@ -265,6 +268,26 @@ function createTwemoji() {
 
         // just a private shortcut
         fromCharCode = String.fromCharCode;
+
+      Object.defineProperties(twemoji, {
+        defaultRegex: {
+          get: function () {
+            // clone upon getting to avoid issues with stateful `lastIndex`
+            return new RegExp(defaultRegex);
+          },
+          enumerable: true
+        },
+        regex: {
+          get: function() {
+            return re;
+          },
+          set: function(value) {
+            // clone upon setting to avoid issues with stateful `lastIndex`
+            re = new RegExp(value);
+          },
+          enumerable: true
+        }
+      });
 
       return twemoji;
 
@@ -366,6 +389,7 @@ function createTwemoji() {
         var
           allText = grabAllTextNodes(node, []),
           length = allText.length,
+          regex = options.regex,
           attrib,
           attrname,
           modified,
@@ -385,7 +409,7 @@ function createTwemoji() {
           subnode = allText[length];
           text = subnode.nodeValue;
           i = 0;
-          while ((match = re.exec(text))) {
+          while ((match = regex.exec(text))) {
             index = match.index;
             if (index !== i) {
               fragment.appendChild(
@@ -486,7 +510,7 @@ function createTwemoji() {
             ret = ret.concat('/>');
           }
           return ret;
-        });
+        }, options.regex);
       }
 
       /**
@@ -552,12 +576,24 @@ function createTwemoji() {
           ext:        how.ext || twemoji.ext,
           size:       how.folder || toSizeSquaredAsset(how.size || twemoji.size),
           className:  how.className || twemoji.className,
-          onerror:    how.onerror || twemoji.onerror
+          onerror:    how.onerror || twemoji.onerror,
+          regex:      how.regex || re
         });
       }
 
-      function replace(text, callback) {
-        return String(text).replace(re, callback);
+      function replace(text, callback, regex) {
+        regex = regex || re;
+
+        if (regex !== defaultRegex) {
+          return String(text).split(htmlGroupedRe).map(function (part, idx) {
+            return idx % 2 === 1
+              ? part
+              : part.replace(regex, callback);
+          }).join('');
+        }
+
+        // fast path because we know `defaultRegex` will never match HTML special chars
+        return String(text).replace(regex, callback);
       }
 
       function test(text) {

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -1950,4 +1950,63 @@ wru.test([{
       );
     });
   }
+},{
+  name: 'custom regex (global)',
+  test: function () {
+    try {
+      wru.assert(
+        'before patch',
+        '<img class="emoji" draggable="false" alt="\u2764" src="' + base + '72x72/2764.png"/>!' ===
+        twemoji.parse('\u2764!')
+      );
+
+      twemoji.regex = /!/g;
+
+      wru.assert(
+        'while patched',
+        '\u2764<img class="emoji" draggable="false" alt="!" src="' + base + '72x72/21.png"/>' ===
+        twemoji.parse('\u2764!')
+      );
+    } catch (err) {
+      throw err;
+    } finally {
+      twemoji.regex = twemoji.defaultRegex;
+
+      wru.assert(
+        'after patch',
+        '<img class="emoji" draggable="false" alt="\u2764" src="' + base + '72x72/2764.png"/>!' ===
+        twemoji.parse('\u2764!')
+      );
+    }
+  }
+},{
+  name: 'custom regex (options passed to `parse`)',
+  test: function () {
+    wru.assert(
+      'no options before',
+      '<img class="emoji" draggable="false" alt="\u2764" src="' + base + '72x72/2764.png"/>!' ===
+      twemoji.parse('\u2764!')
+    );
+
+    wru.assert(
+      'with customized `regex` option',
+      '\u2764<img class="emoji" draggable="false" alt="!" src="' + base + '72x72/21.png"/>' ===
+      twemoji.parse('\u2764!', { regex: /!/g })
+    );
+
+    wru.assert(
+      'no options after',
+      '<img class="emoji" draggable="false" alt="\u2764" src="' + base + '72x72/2764.png"/>!' ===
+      twemoji.parse('\u2764!')
+    );
+  }
+},{
+  name: '`parse` output with custom regex is XSS-safe',
+  test: function () {
+    wru.assert(
+      'XSS safety',
+      '<>&\'"' ===
+      twemoji.parse('<>&\'"', { regex: /<>|&'"/g })
+    );
+  }
 }]);


### PR DESCRIPTION
Fixes https://github.com/jdecked/twemoji/issues/91... I think? Well anyway, it fulfils my use case, maybe @killroy42 can feedback as to whether it fulfils theirs. Notably, it always maps the matched emoji to the relevant icon file name, such that e.g. if "ABC" is matched as an emoji, it always becomes `41-42-43.png` or `41-42-43.svg`. Supplying custom mappings is not supported, but a future PR could build on this one to enable that if it's desirable.

Perf should remain near-identical for cases where the default regex is used, with a small performance hit in cases where a customized regex is supplied. This is due to the XSS-prevention logic, which is assumed unnecessary with the default regex.

Usage:

```js
twemoji.regex = /[\p{RGI_Emoji}--💩]/gv // set to match all RGI emojis, except for poop emoji
twemoji.parse('🦄💩') // only "🦄" is parsed
twemoji.regex = twemoji.defaultRegex // reset
twemoji.parse('🦄💩') // now both are parsed again

// here "ABC" is also parsed as an emoji
twemoji.parse(
    'ABC🦄💩',
    { regex: new RegExp(`ABC|${twemoji.defaultRegex.source}`, 'g') },
)

// to prevent any XSS risk, "<>&'\"" are skipped over,
// even if the user-supplied regex would match them
twemoji.parse('<>&\'"!', { regex: /[<>&'"!]/g }) // only "!" is parsed
```