### PR TITLE
Test: add regression tests for directional arrow VS16 handling (#157)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "fs-extra": "^8.0.1",
     "jsonfile": "^5.0.0",
-    "@twemoji/parser": "17.0.1",
+    "@twemoji/parser": "17.0.2",
     "universalify": "^0.1.2"
   },
   "files": [

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -561,12 +561,10 @@ wru.test([{
     );
   }
 },{
-  // Issue #157: per Unicode, U+2196-2199 default to text presentation and
-  // should only render as emoji when paired with VS16 (FE0F). Today, the
-  // parser matches them bare; the VS16/VS15 cases below already behave
-  // correctly. The bare-arrow assertion fails until @twemoji/parser is
-  // updated to require VS16 for these codepoints.
-  name: 'directional arrow variation selectors (#157)',
+  // All Emoji_Presentation=No emoji should only render as emoji when
+  // paired with VS16. See [the spec](https://unicode.org/reports/tr51/proposed.html#Presentation_Style)
+  // and https://github.com/jdecked/twemoji/issues/157 for more info.
+  name: 'directional arrow variation selectors',
   test: function () {
     // U+2197 + VS16 should render as 2197.png
     var div = document.createElement('div');
@@ -580,7 +578,7 @@ wru.test([{
       div.firstChild.src.indexOf('72x72/2197.png') !== -1
     );
 
-    // U+2197 + VS15 text presentation, should not render
+    // U+2197 + VS15 text presentation, should not render emoji
     div = document.createElement('div');
     div.innerHTML = '\u2197\ufe0e';
     twemoji.parse(div);
@@ -589,28 +587,14 @@ wru.test([{
       div.innerHTML === '\u2197\ufe0e'
     );
 
-    // Bare U+2197 defaults to text per Unicode, should not render.
-    // Currently fails: parser matches bare arrow.
+    // Bare U+2197 defaults to text, should not render emoji
     div = document.createElement('div');
     div.innerHTML = '\u2197';
     twemoji.parse(div);
     wru.assert(
-      'bare U+2197 is not rendered (defaults to text per Unicode)',
+      'bare U+2197 is not rendered (defaults to text)',
       div.innerHTML === '\u2197'
     );
-
-    // Same expectation for the other three diagonal arrows.
-    var diagonals = ['\u2196', '\u2198', '\u2199'];
-    for (var i = 0; i < diagonals.length; i++) {
-      div = document.createElement('div');
-      div.innerHTML = diagonals[i];
-      twemoji.parse(div);
-      wru.assert(
-        'bare U+' + diagonals[i].charCodeAt(0).toString(16) +
-          ' is not rendered (defaults to text per Unicode)',
-        div.innerHTML === diagonals[i]
-      );
-    }
   }
 },{
   name: 'multiple parsing using a callback',

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -550,7 +550,7 @@ wru.test([{
   name: 'unnecessary vs16s',
   test: function () {
     wru.assert('are not parsed in strings',
-     /^<img.*>\ufe0f$/.test(twemoji.parse('\ud83d\ude10\ufe0f')) 
+     /^<img.*>\ufe0f$/.test(twemoji.parse('\ud83d\ude10\ufe0f'))
     );
 
     var div = document.createElement('div');
@@ -559,6 +559,58 @@ wru.test([{
     wru.assert('are not parsed in nodes',
       div.children.length === 1 && div.innerText === '\ufe0f'
     );
+  }
+},{
+  // Issue #157: per Unicode, U+2196-2199 default to text presentation and
+  // should only render as emoji when paired with VS16 (FE0F). Today, the
+  // parser matches them bare; the VS16/VS15 cases below already behave
+  // correctly. The bare-arrow assertion fails until @twemoji/parser is
+  // updated to require VS16 for these codepoints.
+  name: 'directional arrow variation selectors (#157)',
+  test: function () {
+    // U+2197 + VS16 should render as 2197.png
+    var div = document.createElement('div');
+    div.innerHTML = '\u2197\ufe0f';
+    twemoji.parse(div);
+    wru.assert(
+      'U+2197 with VS16 is rendered as emoji',
+      div.firstChild &&
+      div.firstChild.className === 'emoji' &&
+      div.firstChild.getAttribute('alt') === '\u2197\ufe0f' &&
+      div.firstChild.src.indexOf('72x72/2197.png') !== -1
+    );
+
+    // U+2197 + VS15 text presentation, should not render
+    div = document.createElement('div');
+    div.innerHTML = '\u2197\ufe0e';
+    twemoji.parse(div);
+    wru.assert(
+      'U+2197 with VS15 is not rendered (text presentation)',
+      div.innerHTML === '\u2197\ufe0e'
+    );
+
+    // Bare U+2197 defaults to text per Unicode, should not render.
+    // Currently fails: parser matches bare arrow.
+    div = document.createElement('div');
+    div.innerHTML = '\u2197';
+    twemoji.parse(div);
+    wru.assert(
+      'bare U+2197 is not rendered (defaults to text per Unicode)',
+      div.innerHTML === '\u2197'
+    );
+
+    // Same expectation for the other three diagonal arrows.
+    var diagonals = ['\u2196', '\u2198', '\u2199'];
+    for (var i = 0; i < diagonals.length; i++) {
+      div = document.createElement('div');
+      div.innerHTML = diagonals[i];
+      twemoji.parse(div);
+      wru.assert(
+        'bare U+' + diagonals[i].charCodeAt(0).toString(16) +
+          ' is not rendered (defaults to text per Unicode)',
+        div.innerHTML === diagonals[i]
+      );
+    }
   }
 },{
   name: 'multiple parsing using a callback',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@twemoji/parser@17.0.1":
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/@twemoji/parser/-/parser-17.0.1.tgz#5f55fa94fcd5111af55b980b8d6adf724405966f"
-  integrity sha512-Uiq5sq1Wx91Y6C0DczMlu4Gj4nC/0z8UIhT7S53hi/JATaS1oLM5jXygjot7STtyVoIagfnpsBCWaNy3ayfyFw==
+"@twemoji/parser@17.0.2":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/@twemoji/parser/-/parser-17.0.2.tgz#c95ef324565eaa402a231eced895614e29c2b483"
+  integrity sha512-X/P7pHsGOxnrupQYUVetIeuxBGgffFu8CLwoPMMjH9CWmQvlXiCpbTW/BXxMOCWXQojgHdmgdvm6IsCqAQ5nxA==
 
 ajv@^6.5.5:
   version "6.12.6"


### PR DESCRIPTION
## What this is

This PR is Claude Code assisted draft PR based on instructions in #157. It is paired with a fix in jdecked/twemoji-parser/pull/11

## Problem

Per jdecked/twemoji#157, U+2196–U+2199 (the diagonal arrows ↖↗↘↙) currently render as Twemoji images even without a U+FE0F variation selector, despite defaulting to text presentation per the Unicode standard.

This PR doesn't fix the bug, the underlying fix needs to land in `@twemoji/parser` (the regex generator). What it does is add regression tests in `src/test/test.js` that pin down the expected behavior so that once a fixed parser is published and the dependency is bumped here, we have a contract that confirms the right thing is happening:

- `U+2197 + VS16 (FE0F)` → renders as `2197.png` ✅ (passes today)
- `U+2197 + VS15 (FE0E)` → left as text ✅ (passes today)
- bare `U+2196`/`U+2197`/`U+2198`/`U+2199` → should not render ❌ (fails today; this is the bug)

CI will be red until the parser fix lands and we bump `@twemoji/parser` in this repo. 