### PR TITLE
fix: avoid global reference in CommonJS browser bundles

### DIFF
--- a/scripts/create-dist
+++ b/scripts/create-dist
@@ -20,7 +20,7 @@ function distFile(...which) {
 fs.writeFileSync(
   distFile('twemoji.npm.js'),
   [
-    'var location = global.location || {};',
+    'var location = (typeof globalThis !== "undefined" ? globalThis : typeof global !== "undefined" ? global : {}).location || {};',
     fs.readFileSync(distFile('twemoji.js')),
     'if (!location.protocol) {',
     '  twemoji.base = twemoji.base.replace(/^http:/, "");',


### PR DESCRIPTION
Close https://github.com/jdecked/twemoji/issues/165.

Updates the CommonJS entry to safely resolve `location` without assuming Node.js `global` exists, preventing browser bundles from throwing a `ReferenceError`.
